### PR TITLE
feat: Implement product creation functionality

### DIFF
--- a/src/components/apps/ecommerce/addproduct/AdvanceTab.vue
+++ b/src/components/apps/ecommerce/addproduct/AdvanceTab.vue
@@ -17,13 +17,12 @@ const items = ref(['Color', 'Size', 'Material', 'Style']);
 const productStore = useProductStore();
 const sku = ref(productStore.product.sku);
 const codigoBarras = ref(productStore.product.codigoBarras);
-const stock = ref(productStore.product.stock);
-const cantidad = ref(productStore.product.cantidad);
+const stock = ref<number>(Number(productStore.product.stock || '0'));
 
 function saveAdvance() {
-    productStore.setGeneralData({
+    productStore.setAdvancedData({
         sku: sku.value,
-        stock: stock.value,
+        stock: stock.value.toString(),
         codigoBarras: codigoBarras.value
     });
 
@@ -43,17 +42,13 @@ function saveAdvance() {
                     </v-col>
                     <v-col cols="12">
                         <v-label class="font-weight-medium mb-2">Codigo de Barras <span class="text-error ms-1">*</span></v-label>
-                        <VTextField type="text" placeholder="Número de código de barras" variant="outlined" hide-details></VTextField>
+                        <VTextField v-model="codigoBarras" type="text" placeholder="Número de código de barras" variant="outlined" hide-details></VTextField>
                         <p class="textSecondary text-12 mt-1">Introduzca el número de código de barras del producto.</p>
                     </v-col>
                     <v-col cols="12" md="6">
                         <v-label class="font-weight-medium mb-2">Cantidad <span class="text-error ms-1">*</span></v-label>
-                        <VTextField type="number" variant="outlined" hide-details></VTextField>
+                        <VTextField v-model="stock" type="number" variant="outlined" hide-details></VTextField>
                         <p class="textSecondary text-12 mt-1">Introduzca la cantidad del producto</p>
-                    </v-col>
-                    <v-col cols="12" md="6">
-                        <v-label class="font-weight-medium mb-3"><span class="text-error ms-1"></span></v-label>
-                        <VTextField type="number" placeholder="En almacén" variant="outlined" hide-details></VTextField>
                     </v-col>
                     <!-- <v-col cols="12">
                         <v-label class="font-weight-medium mb-2">Allow Backorders</v-label>
@@ -155,7 +150,7 @@ function saveAdvance() {
         </v-card> -->
     </div>
     <div class="d-flex mb-md-0 mb-3 gap-3">
-        <v-btn flat color="primary"> save changes </v-btn>
+        <v-btn flat color="primary" @click="saveAdvance"> save changes </v-btn>
         <v-btn variant="tonal" color="error"> cancel </v-btn>
     </div>
 </template>

--- a/src/components/apps/ecommerce/addproduct/RightSide.vue
+++ b/src/components/apps/ecommerce/addproduct/RightSide.vue
@@ -13,9 +13,6 @@ const fileInput = ref<HTMLInputElement | null>(null);
 const imageUrl = ref<string>(productStore.product.imagen || '');
 const selectedFile = ref<File | null>(null);
 
-const sku = ref(productStore.product.sku);
-const codigoBarras = ref(productStore.product.codigoBarras);
-const stock = ref(productStore.product.stock);
 const estatus = ref(productStore.product.estatus || 'activo');
 
 
@@ -51,9 +48,6 @@ function saveRightSide() {
     // Aquí podrías agregar la lógica de subida de archivo si es necesaria.
     productStore.updateRightSide({
         imagen: imageUrl.value,
-        sku: sku.value,
-        codigoBarras: codigoBarras.value,
-        stock: stock.value.toString(),
         estatus: estatus.value,
     });
     showSuccess('Datos secundarios actualizados');

--- a/src/stores/apps/product.ts
+++ b/src/stores/apps/product.ts
@@ -26,15 +26,24 @@ export const useProductStore  = defineStore('product', {
             estatus: '',
             cantidad: 0
         } as ProductCreation,
-        generalSaved: false
+        generalSaved: false,
+        advancedSaved: false
     }),
     actions: {
         setGeneralData(data: Partial<ProductCreation>){
             this.product = { ...this.product, ...data };
             this.generalSaved = true;
         },
+        setAdvancedData(data: Partial<ProductCreation>){
+            this.product = { ...this.product, ...data };
+            this.advancedSaved = true;
+        },
         updateRightSide(data: Partial<ProductCreation>) {
             this.product = { ...this.product, ...data };
+        },
+        createProduct() {
+            console.log('Creating product:', this.product);
+            this.resetProduct();
         },
         resetProduct() {
             this.product = {
@@ -46,8 +55,10 @@ export const useProductStore  = defineStore('product', {
                 imagen: '',
                 sku: '',
                 estatus: '',
+                cantidad: 0
             };
             this.generalSaved = false;
+            this.advancedSaved = false;
         }
     }
 });

--- a/src/views/apps/inventory/products/create/index.vue
+++ b/src/views/apps/inventory/products/create/index.vue
@@ -1,9 +1,11 @@
 <script setup>
 import { ref } from 'vue';
+import { useProductStore } from '@/stores/apps/product';
 import BaseBreadcrumb from '@/components/shared/BaseBreadcrumb.vue';
 import LeftSide from '@/components/apps/ecommerce/addproduct/LeftSide.vue';
 import RightSide from '@/components/apps/ecommerce/addproduct/RightSide.vue';
 
+const productStore = useProductStore();
 const page = ref({ title: 'Agregar Producto' });
 const breadcrumbs = ref([
     {
@@ -27,6 +29,13 @@ const breadcrumbs = ref([
         </v-col>
         <v-col cols="12" lg="3" md="4">
             <RightSide/>
+        </v-col>
+    </v-row>
+    <v-row class="mt-4">
+        <v-col cols="12" class="text-right">
+            <v-btn color="primary" flat @click="productStore.createProduct()" :disabled="!productStore.generalSaved || !productStore.advancedSaved">
+                Crear Producto
+            </v-btn>
         </v-col>
     </v-row>
 </template>


### PR DESCRIPTION
Adds the UI and Pinia store logic for creating a new product.

Key changes include:

-   **Pinia Store (`product.ts`):**
    -   Added `advancedSaved` state to track advanced form section completion.
    -   Introduced `setAdvancedData` action for saving data from the advanced tab.
    -   Implemented `createProduct` action to simulate product creation (logs data to console) and reset the form state.
    -   Updated `resetProduct` to also reset `advancedSaved` and `cantidad`.

-   **`AdvanceTab.vue`:**
    -   Modified `saveAdvance` to use the new `setAdvancedData` action.
    -   Correctly bound input fields for SKU, barcode, and stock.
    -   Removed redundant 'En almacén' field, using 'Cantidad' for stock.
    -   Ensured stock is saved as a string to the store.

-   **`RightSide.vue`:**
    -   Streamlined `saveRightSide` to only manage `imagen` and `estatus` in the store, removing overlap with `AdvanceTab` for SKU, barcode, and stock.

-   **`index.vue` (Product Create Page):**
    -   Added a main "Crear Producto" button.
    -   This button calls the `createProduct` store action.
    -   The button is conditionally disabled based on `generalSaved` and `advancedSaved` store flags, ensuring all required data sections are addressed before creation.

-   **`LeftSide.vue`:**
    -   Verified that the 'Advanced' tab correctly enables only after the 'General' tab data is saved (`generalSaved` is true).

The changes provide a structured flow for inputting product details across multiple sections, managed by a central Pinia store, culminating in a final creation step.