### PR TITLE
fix: Ensure 'Cantidad' field updates both stock and cantidad in store

### DIFF
--- a/src/components/apps/ecommerce/addproduct/AdvanceTab.vue
+++ b/src/components/apps/ecommerce/addproduct/AdvanceTab.vue
@@ -23,6 +23,7 @@ function saveAdvance() {
     productStore.setAdvancedData({
         sku: sku.value,
         stock: stock.value.toString(),
+        cantidad: stock.value,
         codigoBarras: codigoBarras.value
     });
 

--- a/src/stores/apps/product.ts
+++ b/src/stores/apps/product.ts
@@ -11,6 +11,7 @@ export interface ProductCreation {
     imagen?: string;      // URL o representación de la imagen
     sku: string;
     estatus: string;
+    cantidad?: number;
 };
 
 export const useProductStore  = defineStore('product', {


### PR DESCRIPTION
Addresses your feedback that the quantity was not being saved. The "Cantidad" input in `AdvanceTab.vue` now updates both `product.stock` (as a string) and `product.cantidad` (as a number) in the Pinia product store.

Changes:
-   **`AdvanceTab.vue`:**
    -   The `saveAdvance()` function was updated to pass the numeric value from its `stock` ref (bound to the "Cantidad" input) as `cantidad` in the payload to `setAdvancedData`.
    -   It continues to pass the stringified version of the `stock` ref as `stock`.
-   **`product.ts` (Pinia Store):**
    -   The `ProductCreation` interface was updated to include `cantidad?: number;`. This allows the `setAdvancedData` action to correctly type and merge the `cantidad` value into the product state.