### PR TITLE
feat: Implement product variation management

### DIFF
--- a/src/components/apps/ecommerce/addproduct/AdvanceTab.vue
+++ b/src/components/apps/ecommerce/addproduct/AdvanceTab.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, onMounted } from 'vue';
 import { useEditor, EditorContent } from '@tiptap/vue-3';
 import EditorMenubar from '@/components/forms/plugins/editor/EditorMenubar.vue';
 import StarterKit from '@tiptap/starter-kit';
 import { XIcon } from 'vue-tabler-icons';
 import { useProductStore } from '@/stores/apps/product';
+import type { ProductVariationItem } from '@/stores/apps/product';
+
 const editor = useEditor({
     extensions: [StarterKit]
 });
@@ -19,12 +21,36 @@ const sku = ref(productStore.product.sku);
 const codigoBarras = ref(productStore.product.codigoBarras);
 const stock = ref<number>(Number(productStore.product.stock || '0'));
 
+const currentVariations = ref<ProductVariationItem[]>([]);
+const variationValueInput = ref<string>('');
+
+onMounted(() => {
+    currentVariations.value = structuredClone(productStore.product.variations || []);
+});
+
+function addVariation() {
+    if (!select.value || !variationValueInput.value.trim()) {
+        // Optional: Show some validation/error that type and value are needed
+        return;
+    }
+    currentVariations.value.push({
+        type: select.value,
+        value: variationValueInput.value.trim()
+    });
+    variationValueInput.value = '';
+}
+
+function removeVariation(index: number) {
+    currentVariations.value.splice(index, 1);
+}
+
 function saveAdvance() {
     productStore.setAdvancedData({
         sku: sku.value,
         stock: stock.value.toString(),
         cantidad: stock.value,
-        codigoBarras: codigoBarras.value
+        codigoBarras: codigoBarras.value,
+        variations: currentVariations.value
     });
 
 }
@@ -76,18 +102,24 @@ function saveAdvance() {
                             <v-col cols="4" class="pb-0">
                                 <v-select v-model="select" :items="items" variant="outlined" class="text-body-1" hide-details></v-select>
                             </v-col>
-                            <v-col cols="4" class="pb-0">
-                                <VTextField type="text" placeholder="Variation" variant="outlined" hide-details></VTextField>
-                            </v-col>
-                            <v-col cols="2" class="pb-0">
-                                <v-btn variant="tonal" flat size="large" class="px-0 py-0" color="error" min-width="50"
-                                    ><XIcon height="25" />
-                                </v-btn>
+                            <v-col cols="6" class="pb-0">
+                                <VTextField v-model="variationValueInput" type="text" placeholder="Variation" variant="outlined" hide-details></VTextField>
                             </v-col>
                             <v-col cols="12">
-                                <v-btn variant="tonal" color="primary"><span class="text-20 me-1">+</span> Add another variation</v-btn>
+                                <v-btn variant="tonal" color="primary" @click="addVariation"><span class="text-20 me-1">+</span> Add another variation</v-btn>
                             </v-col>
                         </v-row>
+                         <!-- Display Added Variations -->
+                        <div v-if="currentVariations.length > 0" class="mt-6">
+                            <h6 class="text-h6 mb-2">Variaciones Agregadas:</h6>
+                            <v-list lines="one" border>
+                                <v-list-item v-for="(variation, index) in currentVariations" :key="index" :title="`${variation.type}: ${variation.value}`">
+                                    <template v-slot:append>
+                                        <v-btn icon="mdi-close" flat size="small" @click="removeVariation(index)" color="error"></v-btn>
+                                    </template>
+                                </v-list-item>
+                            </v-list>
+                        </div>
                     </v-col>
                 </v-row>
             </v-card-text>

--- a/src/stores/apps/product.ts
+++ b/src/stores/apps/product.ts
@@ -2,6 +2,11 @@ import { defineStore } from 'pinia';
 
 import type { Products } from '@/types/apps/EcommerceType';
 
+export interface ProductVariationItem {
+    type: string;
+    value: string;
+}
+
 export interface ProductCreation {
     nombre: string;
     descripcion: string;
@@ -12,6 +17,7 @@ export interface ProductCreation {
     sku: string;
     estatus: string;
     cantidad?: number;
+    variations?: ProductVariationItem[];
 };
 
 export const useProductStore  = defineStore('product', {
@@ -25,7 +31,8 @@ export const useProductStore  = defineStore('product', {
             imagen: '',
             sku: '',
             estatus: '',
-            cantidad: 0
+            cantidad: 0,
+            variations: []
         } as ProductCreation,
         generalSaved: false,
         advancedSaved: false
@@ -56,7 +63,8 @@ export const useProductStore  = defineStore('product', {
                 imagen: '',
                 sku: '',
                 estatus: '',
-                cantidad: 0
+                cantidad: 0,
+                variations: []
             };
             this.generalSaved = false;
             this.advancedSaved = false;


### PR DESCRIPTION
Adds functionality to manage product variations in `AdvanceTab.vue` and store them in Pinia.

-   **`product.ts` (Pinia Store):**
    -   Defined a new interface `ProductVariationItem { type: string; value: string; }`.
    -   Added `variations?: ProductVariationItem[];` to the `ProductCreation` interface.
    -   Initialized `product.variations` as `[]` in the state.
    -   Updated `resetProduct` to clear `variations`.
    -   `setAdvancedData` now correctly processes and stores the `variations` array.

-   **`AdvanceTab.vue`:**
    -   Imported `ProductVariationItem`.
    -   Added `currentVariations = ref<ProductVariationItem[]>([]);` to manage variations in the UI, initialized on mount from the store.
    -   Added `variationValueInput = ref<string>('');` for the variation value text field.
    -   Implemented `addVariation()` function to add new variations to `currentVariations` from UI inputs.
    -   Implemented `removeVariation(index)` function to remove variations from `currentVariations`.
    -   Updated the template to:
        -   Bind the "Add another variation" button to `addVariation()`.
        -   Bind the variation value input field to `variationValueInput`.
        -   Display the list of `currentVariations`, with each item showing its type and value, and a button to trigger `removeVariation(index)`.
        -   Removed a redundant/misplaced 'X' button from the input row.
    -   Modified `saveAdvance()` to include `variations: currentVariations.value` in the data payload sent to `productStore.setAdvancedData()`.

This enables you to define multiple key-value pair variations for a product (e.g., Color: Red, Size: Medium), which are then stored and available as part of the overall product data.