### PR TITLE
Okay, I've made a fix to resolve a "DataCloneError" that was occurrin…

### DIFF
--- a/src/components/apps/ecommerce/addproduct/AdvanceTab.vue
+++ b/src/components/apps/ecommerce/addproduct/AdvanceTab.vue
@@ -25,7 +25,7 @@ const currentVariations = ref<ProductVariationItem[]>([]);
 const variationValueInput = ref<string>('');
 
 onMounted(() => {
-    currentVariations.value = structuredClone(productStore.product.variations || []);
+    currentVariations.value = JSON.parse(JSON.stringify(productStore.product.variations || []));
 });
 
 function addVariation() {


### PR DESCRIPTION
…g when cloning variations in the "AdvanceTab" component.

I've replaced `structuredClone` with `JSON.parse(JSON.stringify())` for initializing the `currentVariations` ref within the `onMounted` hook in `AdvanceTab.vue`.

This change addresses the error: `DataCloneError: Failed to execute 'structuredClone' on 'Window': [object Array] could not be cloned.` The `JSON.parse(JSON.stringify())` method provides a more reliable way to deep clone simple, JSON-compatible objects and arrays, like the `ProductVariationItem[]` used for your product variations.

This should ensure the "Advanced" tab loads correctly and the variation management functionality works as expected.